### PR TITLE
Fix when allowing suid rules

### DIFF
--- a/module/system/bin/chroot-distro
+++ b/module/system/bin/chroot-distro
@@ -1826,7 +1826,7 @@ command_login() {
 	# Enable SUID on /data
 	# Extract the device block for /data in /proc/mounts
 
-	local DEVICE_BLOCK=$(busybox grep -w "/data" /proc/mounts | busybox awk '{print $1}' | head -n 1)
+	DEVICE_BLOCK="$(busybox grep -w "/data" /proc/mounts | busybox awk '{print $1}' | head -n 1)"
 
 	if [ -n "$DEVICE_BLOCK" ]; then
 		# Remount with dev and suid options


### PR DESCRIPTION
<img width="1080" height="2424" alt="Screenshot_20260215-194815" src="https://github.com/user-attachments/assets/59f31e18-d68a-4fd7-acd5-df421c3232e3" />
<img width="1080" height="2424" alt="Screenshot_20260215-194554" src="https://github.com/user-attachments/assets/320e91af-34ba-4d7f-b5e7-69218fc99663" />

The tool itself is cool, however, I noticed that the suid rules weren't correctly fixed on my Pixel 9a. This is a problem. So I found the relevant section in your code, tested the command manually, and then pieced together a working version. I've integrated this fix here; it manually searches for the device block in /proc/mounts, remounts explicitly using it, and yes, it works. It would be great if you integrated it. I think you'd then automatically support more devices.