### PR TITLE
Adding other relevant android specific User and Group ID's

### DIFF
--- a/module/system/bin/chroot-distro
+++ b/module/system/bin/chroot-distro
@@ -1254,11 +1254,17 @@ command_install() {
 
 	# Add other Android groups
 	busybox cat <<-EOF >>"${INSTALLED_ROOTFS_DIR:?}/${distro_name:?}/etc/group"
+		aid_bluetooth:x:1002:
 		aid_graphics:x:1003:
 		aid_input:x:1004:
 		aid_audio:x:1005:
 		aid_video:x:1006:
 		aid_drm:x:1007:
+		aid_wifi:x:1010:
+		aid_usb:x:1018:
+		aid_bt_admin:x:3001:
+		aid_bt_net:x:3002:
+		aid_admin:x:3005:
 	EOF
 
 	# get the gid fist from the current system, it it unable to fetch


### PR DESCRIPTION
During my work with chroot distributions, I occasionally encountered problems with Bluetooth, Wi-Fi, and USB hardware, which I was able to resolve by adding the following GIDs, which I could then assign to the users. Since I already configure them by default on the first boot, and I assume others do too, regardless of this tool, it would be great if they were configured directly during installation. I added them to the relevant code section and have already successfully flashed them on my system; after installation, they are registered and can be assigned to users as needed. And thank you very much for this cool tool; it greatly simplifies managing multiple Linux environments, and this addition has definitely made my setup workflow faster.