### PR TITLE
void: bump to 20250401

### DIFF
--- a/distro-build/void.sh
+++ b/distro-build/void.sh
@@ -1,4 +1,4 @@
-dist_version="20250202"
+dist_version="20250401"
 
 bootstrap_distribution() {
 	sudo rm -f "${ROOTFS_DIR}"/void-*.tar.xz


### PR DESCRIPTION
Automated update for **void**.

- Current version: `20250202`
- New version: `20250401`

This PR updates the distro version in `distro-build/void.sh`.