### PR TITLE
trisquel: bump to 12.0

### DIFF
--- a/distro-build/trisquel.sh
+++ b/distro-build/trisquel.sh
@@ -1,6 +1,6 @@
 # Put only current stable version here!
-dist_version="11.0"
-dist_codename="aramo"
+dist_version="12.0"
+dist_codename="ecne"
 
 bootstrap_distribution() {
 	sudo rm -f "${ROOTFS_DIR}"/trisquel-*-"${dist_version}".tar.xz


### PR DESCRIPTION
Automated update for **trisquel**.

- Current version: `11.0`
- New version: `12.0`

This PR updates the distro version in `distro-build/trisquel.sh`.