### PR TITLE
rockylinux: bump to 10.1

### DIFF
--- a/distro-build/rockylinux.sh
+++ b/distro-build/rockylinux.sh
@@ -1,4 +1,4 @@
-dist_version="10.0"
+dist_version="10.1"
 
 bootstrap_distribution() {
 	sudo rm -f "${ROOTFS_DIR}"/rocky-*.tar.xz


### PR DESCRIPTION
Automated update for **rockylinux**.

- Current version: `10.0`
- New version: `10.1`

This PR updates the distro version in `distro-build/rockylinux.sh`.