### PR TITLE
manjaro: bump to 20260216

### DIFF
--- a/distro-build/manjaro.sh
+++ b/distro-build/manjaro.sh
@@ -1,4 +1,4 @@
-dist_version="20251208"
+dist_version="20260216"
 
 bootstrap_distribution() {
 	sudo rm -f "${ROOTFS_DIR}"/manjaro-*.tar.xz


### PR DESCRIPTION
Automated update for **manjaro**.

- Current version: `20251208`
- New version: `20260216`

This PR updates the distro version in `distro-build/manjaro.sh`.