### PR TITLE
debian: bump to 13.4

### DIFF
--- a/distro-build/debian.sh
+++ b/distro-build/debian.sh
@@ -1,5 +1,5 @@
 # Put only current stable version here!
-dist_version="13.3"
+dist_version="13.4"
 dist_codename="trixie"
 
 bootstrap_distribution() {


### PR DESCRIPTION
Automated update for **debian**.

- Current version: `13.3`
- New version: `13.4`

This PR updates the distro version in `distro-build/debian.sh`.