### PR TITLE
feat(download): add Termux fallback download methods

### DIFF
--- a/module/module.prop
+++ b/module/module.prop
@@ -1,7 +1,7 @@
 id=chroot-distro
 name=chroot-distro
-version=1.5.5
-versionCode=32
+version=1.5.4
+versionCode=31
 author=@sabamdarif
 description=Install Gnu/Linux distributions on Android
 updateJson=https://raw.githubusercontent.com/sabamdarif/chroot-distro/refs/heads/main/module/update.json


### PR DESCRIPTION
This commit adds fallback paths for curl, wget, and busybox wget from the Termux environment (/data/data/com.termux/files/usr/bin/*).

Inspired by this [comment](https://github.com/sabamdarif/chroot-distro/issues/30#issuecomment-4097124403)

Resolves #30