### PR TITLE
alpine: bump to 3.23.4

### DIFF
--- a/distro-build/alpine.sh
+++ b/distro-build/alpine.sh
@@ -1,4 +1,4 @@
-dist_version="3.23.3"
+dist_version="3.23.4"
 
 bootstrap_distribution() {
 	sudo rm -f "${ROOTFS_DIR}"/alpine-*.tar.xz


### PR DESCRIPTION
Automated update for **alpine**.

- Current version: `3.23.3`
- New version: `3.23.4`

This PR updates the distro version in `distro-build/alpine.sh`.