### PR TITLE
archlinux: bump to 2026.05.01

### DIFF
--- a/distro-build/archlinux.sh
+++ b/distro-build/archlinux.sh
@@ -1,4 +1,4 @@
-dist_version="2026.04.01"
+dist_version="2026.05.01"
 
 bootstrap_distribution() {
 	sudo rm -f "${ROOTFS_DIR}"/archlinux-*.tar.xz


### PR DESCRIPTION
Automated update for **archlinux**.

- Current version: `2026.04.01`
- New version: `2026.05.01`

This PR updates the distro version in `distro-build/archlinux.sh`.