### PR TITLE
ubuntu: bump to 26.04

### DIFF
--- a/distro-build/ubuntu.sh
+++ b/distro-build/ubuntu.sh
@@ -1,6 +1,6 @@
 # After changing, update the DISTRO_NAME below.
-dist_version="25.10"
-dist_codename="questing"
+dist_version="26.04"
+dist_codename="resolute"
 
 bootstrap_distribution() {
 	sudo rm -f "${ROOTFS_DIR}"/ubuntu-*-"${dist_version}".tar.xz


### PR DESCRIPTION
Automated update for **ubuntu**.

- Current version: `25.10`
- New version: `26.04`

This PR updates the distro version in `distro-build/ubuntu.sh`.