### PR TITLE
manjaro: bump to 20260511

### DIFF
--- a/distro-build/manjaro.sh
+++ b/distro-build/manjaro.sh
@@ -1,4 +1,4 @@
-dist_version="20260413"
+dist_version="20260511"
 
 bootstrap_distribution() {
 	sudo rm -f "${ROOTFS_DIR}"/manjaro-*.tar.xz


### PR DESCRIPTION
Automated update for **manjaro**.

- Current version: `20260413`
- New version: `20260511`

This PR updates the distro version in `distro-build/manjaro.sh`.