### PR TITLE
feat(login,build): support foreign architectures with qemu binfmt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,9 +234,10 @@ paths by hand.
 
 **Debug/escape hatches, deliberately undocumented:**
 `CD_NO_DAEMON=1` (skip the daemon socket), `CD_NO_CAP_DROP=1` (keep the full
-capability bounding set), `CD_SU_PATH` / `CD_SU_MOUNT_MASTER=1` (Termux `su`
-selection and namespace), `CD_SUBID_BASE` (user-namespace subid base),
-`CD_PUSH_CHUNK_SIZE`, `CD_SECRET_FILE` (internal, set by `elevate.py`).
+capability bounding set), `CD_NO_BINFMT=1` (never register a binfmt_misc
+handler), `CD_SU_PATH` / `CD_SU_MOUNT_MASTER=1` (Termux `su` selection and
+namespace), `CD_SUBID_BASE` (user-namespace subid base), `CD_PUSH_CHUNK_SIZE`,
+`CD_SECRET_FILE` (internal, set by `elevate.py`).
 
 ### This file
 
@@ -450,6 +451,7 @@ the caller (`build_engine/constants.is_host_exec_var`, applied in
 | `helpers/android.py`        | the Termux-side fixups, and nothing on Linux              |
 | `helpers/rootfs.py`         | the guest `/etc` files this program writes                |
 | `helpers/owner.py`          | a `--chown` spec to the numeric pair                      |
+| `helpers/binfmt.py`         | the binfmt_misc entry a foreign-arch guest runs on        |
 | `arch.py`                   | host arch, image arch, and what a rootfs turned out to be |
 | `commands/info.py`          | one report a bug can be filed with                        |
 | `commands/kernel_config.py` | what the running kernel was built with                    |

--- a/README.md
+++ b/README.md
@@ -123,6 +123,13 @@ chroot-distro install myuser/private-image:tag
 
 Downloaded layers are cached, so installing the same image again works offline.
 
+A container for another CPU needs QEMU's user-mode emulator on the host: install
+`qemu-user-static` (Linux) or `qemu-user-aarch64` and friends (Termux). `login`
+then registers it with the kernel's `binfmt_misc` the first time you enter the
+container, and the registration stays until the host reboots. `chroot-distro
+info` lists which architectures are covered. Nothing to install for your CPU's
+own 32-bit half: `i686` on `x86_64` and `arm` on `aarch64` run directly.
+
 ### login
 
 ```
@@ -519,6 +526,7 @@ All of these are optional.
 - **Isolation is partial.** `--isolated` covers mount, PID, UTS, and IPC namespaces. It is not a full container runtime like Docker or Podman.
 - **Builds are not full BuildKit.** `RUN` steps execute under chroot. A few BuildKit features are rejected with an error, and multi-platform images are not produced.
 - **`push` is single-architecture.** Build and push once per CPU type.
+- **Foreign architectures need the kernel's help.** Emulation goes through `binfmt_misc`, so a kernel built without `CONFIG_BINFMT_MISC` cannot run an image for another CPU. `chroot-distro info` reports it.
 - **Backups capture files only.** Running programs are not saved by `backup`/`restore`.
 - **Registry login is env-var only.** Set `CD_DOCKER_AUTH`. Docker's `config.json` credential helpers are not read.
 

--- a/src/chroot_distro/arch.py
+++ b/src/chroot_distro/arch.py
@@ -15,6 +15,11 @@ platform the files do not match. `supports_32bit` asks the kernel through
 `personality(PER_LINUX32)` and puts the previous value back, since on arm64
 whether 32-bit userspace runs is a kernel build option and not something the
 machine name says.
+
+`needs_emulation` is the single place that answers whether a rootfs needs QEMU,
+so a 32-bit guest on a 64-bit host of the same family asks `supports_32bit`
+instead of counting as foreign. `ELF_MACHINE_BY_ARCH` is the machine table the
+other way round, for the header `helpers/binfmt.py` registers a match on.
 """
 
 import ctypes
@@ -66,6 +71,21 @@ _ELF_MACHINE_MAP = {
     183: "aarch64",  # EM_AARCH64
     243: "riscv64",  # EM_RISCV
 }
+
+ELF_MACHINE_BY_ARCH = {name: machine for machine, name in _ELF_MACHINE_MAP.items()}
+
+# Host/guest pairs whose 32-bit userspace the 64-bit CPU runs without emulation.
+_NATIVE_32BIT = frozenset({("x86_64", "i686"), ("aarch64", "arm")})
+
+
+def needs_emulation(image_arch: str, host_arch: str = "") -> bool:
+    """Return True if *image_arch* binaries cannot run on this CPU as they are."""
+    host = host_arch or get_device_cpu_arch()
+    if image_arch == host:
+        return False
+    if (host, image_arch) in _NATIVE_32BIT:
+        return not supports_32bit()
+    return True
 
 
 def _elf_arch(path: str) -> str:

--- a/src/chroot_distro/commands/build.py
+++ b/src/chroot_distro/commands/build.py
@@ -36,13 +36,14 @@ from contextlib import ExitStack
 from types import SimpleNamespace
 
 from chroot_distro import dirfd
-from chroot_distro.arch import get_device_cpu_arch, normalize_arch
+from chroot_distro.arch import get_device_cpu_arch, needs_emulation, normalize_arch
 from chroot_distro.commands.install import command_install
 from chroot_distro.constants import (
     PROGRAM_NAME,
     RUNTIME_DIR,
 )
 from chroot_distro.helpers import namespace
+from chroot_distro.helpers.binfmt import ensure_handler
 from chroot_distro.helpers.build_engine import (
     BuildEngine,
     BuildError,
@@ -140,6 +141,21 @@ def command_build(args: typing.Any) -> None:
             sys.exit(1)
     else:
         target_arch = get_device_cpu_arch()
+
+    # Every RUN step chroots into the target rootfs, so a foreign build needs the
+    # same handler a foreign login does. A build with no RUN never execs a guest
+    # binary, so there it is only a warning.
+    if needs_emulation(target_arch):
+        interpreter, reason = ensure_handler(target_arch)
+        if interpreter is None:
+            detail = (
+                f"Building for '{target_arch}' on a '{get_device_cpu_arch()}' host, "
+                f"and no emulator was registered ({reason})."
+            )
+            if any(ins.get("name") == "RUN" for ins in instructions):
+                crit_error(f"{detail} RUN steps cannot execute.")
+                sys.exit(1)
+            warn(detail)
 
     if install_as:
         require_valid_name(install_as, kind="--install-as value")

--- a/src/chroot_distro/commands/help/pages.py
+++ b/src/chroot_distro/commands/help/pages.py
@@ -398,7 +398,9 @@ HELP_PAGES: dict[str, dict[str, typing.Any]] = {
                 "Override the target CPU architecture. Accepts native "
                 "names (aarch64, arm, i686, riscv64, x86_64) or Docker "
                 "platform strings (linux/arm64, linux/amd64, linux/arm/v7, "
-                "linux/386, linux/riscv64).",
+                "linux/386, linux/riscv64). A foreign architecture needs "
+                "QEMU's user-mode emulator installed on the host; login "
+                "registers it with binfmt_misc on first entry.",
             ),
             ("-q, --quiet", "Suppress non-error output."),
         ],

--- a/src/chroot_distro/commands/info.py
+++ b/src/chroot_distro/commands/info.py
@@ -30,7 +30,7 @@ import shutil
 import sys
 from dataclasses import dataclass, field
 
-from chroot_distro.arch import detect_installed_arch, get_device_cpu_arch, supports_32bit
+from chroot_distro.arch import detect_installed_arch, get_device_cpu_arch, needs_emulation, supports_32bit
 from chroot_distro.commands.kernel_config import (
     CONFIG_BUILTIN,
     CONFIG_MODULE,
@@ -60,6 +60,7 @@ from chroot_distro.constants import (
     RUNTIME_DIR,
     TERMUX_APP_PACKAGE,
 )
+from chroot_distro.helpers.binfmt import BINFMT_DIR, covered_arches
 from chroot_distro.locking import container_busy_status
 from chroot_distro.message import C, msg
 from chroot_distro.paths import container_manifest, container_rootfs
@@ -264,20 +265,13 @@ def _data_mount_flags() -> tuple[str, str]:
 
 def _binfmt_qemu_status(needs_emulation: bool) -> tuple[str, str]:
     """Return (value, level) describing binfmt_misc + QEMU availability."""
-    binfmt_dir = "/proc/sys/fs/binfmt_misc"
-    if not os.path.isdir(binfmt_dir):
+    if not os.path.isdir(BINFMT_DIR):
         value = "binfmt_misc not mounted"
         return value, ("bad" if needs_emulation else "info")
-    qemu_handlers: list[str] = []
-    try:
-        for entry in sorted(os.listdir(binfmt_dir)):
-            if entry.startswith("qemu-"):
-                qemu_handlers.append(entry[len("qemu-") :])
-    except OSError:
-        pass
-    if qemu_handlers:
-        return f"binfmt_misc + qemu ({', '.join(qemu_handlers)})", "ok"
-    value = "binfmt_misc mounted, no qemu handler registered"
+    covered = covered_arches()
+    if covered:
+        return f"binfmt_misc + qemu ({', '.join(covered)})", "ok"
+    value = "binfmt_misc mounted, no emulator registered"
     return value, ("bad" if needs_emulation else "info")
 
 
@@ -542,12 +536,7 @@ def _analyze_image(info: _ImageInfo, host_arch: str) -> None:
         # minimal/distroless images legitimately lack /etc files.
         info.findings.append("no recognizable rootfs layout (install may be incomplete)")
 
-    if (
-        info.arch not in (_NA, "")
-        and host_arch not in (_NA, "")
-        and info.arch != host_arch
-        and not (host_arch in ("x86_64", "aarch64") and info.arch in ("i686", "arm"))
-    ):
+    if info.arch not in (_NA, "") and host_arch not in (_NA, "") and needs_emulation(info.arch, host_arch):
         info.findings.append(f"arch '{info.arch}' differs from host '{host_arch}' (needs emulation)")
 
 

--- a/src/chroot_distro/commands/login/__init__.py
+++ b/src/chroot_distro/commands/login/__init__.py
@@ -267,39 +267,65 @@ def _merge_image_path(image_path: str, system_path: str) -> str:
     return ":".join(merged)
 
 
-def _check_arch_mismatch(container_path: str) -> None:
-    """Warn if the image architecture does not match the host CPU."""
-    from chroot_distro.arch import get_device_cpu_arch, normalize_arch
+def _manifest_arch(container_path: str) -> str:
+    """Return the arch the manifest claims, or "" when it claims none."""
+    from chroot_distro.arch import normalize_arch
 
     try:
         with open(os.path.join(container_path, "manifest.json")) as fh:
             data = json.load(fh)
-        img_arch_raw = data.get("arch") or (data.get("image_config") or {}).get("architecture", "")
-        if not img_arch_raw:
-            return
-        img_arch = normalize_arch(img_arch_raw) or img_arch_raw
-        host_arch = get_device_cpu_arch()
-        if img_arch == host_arch:
-            return
-        binfmt_dir = "/proc/sys/fs/binfmt_misc"
-        if os.path.isdir(binfmt_dir):
-            for entry in os.listdir(binfmt_dir):
-                if entry in ("register", "status"):
-                    continue
-                try:
-                    with open(os.path.join(binfmt_dir, entry)) as fh:
-                        if "enabled" in fh.read():
-                            return
-                except OSError:
-                    continue
-        warn(
-            f"Image architecture '{img_arch}' does not match host "
-            f"architecture '{host_arch}'. Binaries may fail to execute. "
-            f"Install qemu-user-static and register binfmt_misc handlers "
-            f"for cross-architecture support."
-        )
-    except (OSError, ValueError, json.JSONDecodeError) as exc:
-        log.warning("Could not check container/host architecture mismatch: %s", exc)
+    except (OSError, ValueError) as exc:
+        log.debug("Could not read the manifest's architecture: %s", exc)
+        return ""
+    raw = data.get("arch") or (data.get("image_config") or {}).get("architecture", "")
+    if not raw:
+        return ""
+    return normalize_arch(raw) or raw
+
+
+def _ensure_guest_arch_runnable(container_path: str, rootfs: str) -> None:
+    """Register a QEMU handler for a foreign-arch guest, or refuse to enter it.
+
+    Two sources, and either one alone is enough to go looking for a handler: the
+    manifest's claim, and the arch the rootfs's own ELF headers report. Only the
+    second aborts the login, because a tarball can arrive with no manifest or
+    one naming a platform its files do not match, and a manifest's word alone
+    must not lock the user out of a container that runs fine.
+
+    Runs before the mounts, but the `F` flag in the registration is what makes
+    that irrelevant: the kernel holds the emulator open, so it never has to be
+    reachable from inside the rootfs.
+    """
+    from chroot_distro.arch import detect_installed_arch, get_device_cpu_arch, needs_emulation
+    from chroot_distro.helpers.binfmt import ensure_handler
+    from chroot_distro.message import quote_path
+
+    host_arch = get_device_cpu_arch()
+    on_disk = detect_installed_arch(rootfs)
+    confirmed = on_disk not in ("", "unknown") and needs_emulation(on_disk, host_arch)
+    claimed = _manifest_arch(container_path)
+
+    if confirmed:
+        guest_arch = on_disk
+    elif claimed and needs_emulation(claimed, host_arch):
+        guest_arch = claimed
+    else:
+        return
+
+    interpreter, reason = ensure_handler(guest_arch)
+    if interpreter:
+        log.debug("%s runs '%s' binaries for this session", interpreter, guest_arch)
+        return
+
+    detail = (
+        f"Container architecture '{quote_path(guest_arch)}' does not match host "
+        f"architecture '{host_arch}', and no emulator was registered ({reason}). "
+        f"Install a QEMU user-mode emulator for '{quote_path(guest_arch)}'."
+    )
+    if confirmed:
+        crit_error(f"{detail} Its binaries cannot execute.")
+        sys.exit(1)
+    warn(f"{detail} Binaries may fail to execute.")
 
 
 def _build_termux_env(rootfs, container_path, extra_env, minimal, isolated, container_name=""):
@@ -502,7 +528,7 @@ def _command_login_inner_once(container_name: str, args) -> None:
     dist_type = _detect_dist_type(rootfs)
     container_path = container_dir(container_name)
 
-    _check_arch_mismatch(container_path)
+    _ensure_guest_arch_runnable(container_path, rootfs)
 
     # Precedence: CLI flag > CD_* env > image default. Already resolved by
     # command_run on the `run` path, so these are no-ops there.

--- a/src/chroot_distro/commands/login/bindings.py
+++ b/src/chroot_distro/commands/login/bindings.py
@@ -199,13 +199,19 @@ def _usb_specials() -> list[SpecialMount]:
     ]
 
 
-def _binfmt_misc_special(*, fresh_proc: bool = True) -> SpecialMount | None:
+def _binfmt_misc_special(*, fresh_proc: bool = True, use_userns: bool = False) -> SpecialMount | None:
     """Mount binfmt_misc inside the chroot when the kernel supports it.
 
-    The chroot's /proc is always a fresh procfs, so the host's registrations
-    are never inherited; *fresh_proc*=False instead skips the mount when the
-    host already has one.
+    Never under a user namespace: since Linux 6.7 the entries hang off the user
+    namespace and one without its own mount inherits its nearest ancestor's, so
+    a fresh instance here would hand the session an empty set and shadow the
+    QEMU handler a foreign-arch guest needs. *fresh_proc*=False skips the mount
+    when the host already has one.
     """
+    if use_userns:
+        log.debug("binfmt_misc: not mounted, so the user namespace inherits the host's entries")
+        return None
+
     if not fresh_proc and os.path.exists("/proc/sys/fs/binfmt_misc/register"):
         return None
 
@@ -325,7 +331,7 @@ def get_special_mounts(
         specials.extend(_usb_specials())
 
     if enable_binfmt:
-        sm = _binfmt_misc_special(fresh_proc=True)
+        sm = _binfmt_misc_special(fresh_proc=True, use_userns=use_userns)
         if sm:
             specials.append(sm)
 

--- a/src/chroot_distro/helpers/binfmt.py
+++ b/src/chroot_distro/helpers/binfmt.py
@@ -1,0 +1,212 @@
+# SPDX-License-Identifier: GPL-3.0-only
+# Copyright (C) 2025-2026 Md Arif
+"""Register a binfmt_misc handler, so a foreign-arch guest can exec its own binaries.
+
+The kernel decides how to run a foreign ELF from the entries under
+`/proc/sys/fs/binfmt_misc`, and adding one is a write to `register`, so nothing
+here calls `update-binfmts` or `qemu-binfmt-conf.sh`. The emulator is not run by
+this program either: the kernel execs it, when the guest execs a binary whose
+header matches.
+
+Three parts of the registration are deliberate.
+
+`F` is required, not a nicety. It makes the kernel open the interpreter at
+registration time and keep that file, so the emulator does not have to exist
+inside the rootfs. Without it the lookup happens at exec time in the caller's
+mount namespace, which by then is the chroot, where the host's qemu is not.
+
+`C` (take credentials from the binary) is left out. It is what makes setuid work
+under emulation, and it also turns every container rootfs into a host-wide
+escalation: an entry applies to every exec in the user namespace, so any local
+user could run a guest's foreign setuid-root binary straight from its rootfs
+path. Someone who wants that registers their own entry, and `ensure_handler`
+then leaves it alone.
+
+Coverage is answered by replaying the kernel's own match, magic and mask against
+the target's ELF header, not by reading entry names: the name belongs to whoever
+registered the entry and says nothing about the arch it answers for.
+
+Since Linux 6.7 entries live on the user namespace, and a namespace without its
+own binfmt_misc mount falls back to the nearest ancestor that has one. That
+fallback is why `commands/login/bindings._binfmt_misc_special` must not mount a
+fresh instance inside a session's user namespace: an empty instance shadows
+whatever was registered here.
+"""
+
+import logging
+import os
+import struct
+
+from chroot_distro.arch import ELF_MACHINE_BY_ARCH
+from chroot_distro.constants import TERMUX_PREFIX
+from chroot_distro.message import log_info
+
+log = logging.getLogger(__name__)
+
+BINFMT_DIR = "/proc/sys/fs/binfmt_misc"
+_REGISTER = f"{BINFMT_DIR}/register"
+
+# fs/binfmt_misc.c caps an interpreter path at 127 bytes.
+_MAX_INTERPRETER = 127
+
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+# EI_CLASS per arch; the e_machine half comes from arch.py, and every arch this
+# program knows is little-endian, so EI_DATA is fixed at 1.
+_ELF_CLASS = {"aarch64": 2, "arm": 1, "i686": 1, "riscv64": 2, "x86_64": 2}
+
+# QEMU's own name for each user-mode emulator ("i686" is "i386" there).
+_QEMU_BINARY = {
+    "aarch64": "qemu-aarch64",
+    "arm": "qemu-arm",
+    "i686": "qemu-i386",
+    "riscv64": "qemu-riscv64",
+    "x86_64": "qemu-x86_64",
+}
+
+# Where a distro or Termux package drops the emulator. A static build wins: a
+# dynamic one (all Termux ships) only runs when its libraries are in the guest.
+_SEARCH_DIRS = (f"{TERMUX_PREFIX}/bin", "/usr/bin", "/usr/local/bin", "/bin")
+
+
+def _elf_signature(arch: str) -> tuple[bytes, bytes] | None:
+    """Return (magic, mask) matching the first 20 bytes of *arch*'s ELF header."""
+    machine = ELF_MACHINE_BY_ARCH.get(arch)
+    elf_class = _ELF_CLASS.get(arch)
+    if machine is None or elf_class is None:
+        return None
+    # e_ident (16) then e_type=ET_EXEC and e_machine; EI_OSABI onwards is zero.
+    magic = b"\x7fELF" + bytes((elf_class, 1, 1)) + bytes(9) + struct.pack("<HH", 2, machine)
+    # 0xfe on e_type's low byte lets ET_DYN (a PIE) match this ET_EXEC template.
+    mask = b"\xff" * 7 + b"\x00" + b"\xff" * 8 + b"\xfe\xff\xff\xff"
+    return magic, mask
+
+
+def _parse_entry(text: str) -> tuple[str, int, bytes, bytes] | None:
+    """Return (interpreter, offset, magic, mask) for one enabled magic entry.
+
+    None for anything this cannot judge: a disabled entry, an extension match,
+    or a 'B' entry, whose interpreter a BPF program picks at exec time.
+    """
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "enabled":
+        return None
+    interpreter = ""
+    offset = 0
+    magic = b""
+    mask = b""
+    try:
+        for line in lines[1:]:
+            key, _, value = line.partition(" ")
+            if key == "interpreter":
+                interpreter = value.strip()
+            elif key == "offset":
+                offset = int(value)
+            elif key == "magic":
+                magic = bytes.fromhex(value.strip())
+            elif key == "mask":
+                mask = bytes.fromhex(value.strip())
+    except ValueError:
+        return None
+    if not interpreter or not magic or offset < 0:
+        return None
+    return interpreter, offset, magic, mask or b"\xff" * len(magic)
+
+
+def _entry_matches(offset: int, magic: bytes, mask: bytes, header: bytes) -> bool:
+    """Return True if an entry's (offset, magic, mask) would match *header*.
+
+    An entry reaching past the 20-byte header reads as no match, so the worst
+    case is registering a second entry the kernel would have matched anyway.
+    """
+    end = offset + len(magic)
+    if end > len(header) or len(mask) < len(magic):
+        return False
+    chunk = header[offset:end]
+    return all(c & m == g & m for c, g, m in zip(chunk, magic, mask, strict=False))
+
+
+def registered_interpreter(arch: str) -> str | None:
+    """Return the interpreter of an enabled entry that already answers for *arch*."""
+    signature = _elf_signature(arch)
+    if signature is None:
+        return None
+    header = signature[0]
+    try:
+        names = os.listdir(BINFMT_DIR)
+    except OSError:
+        return None
+    for name in names:
+        if name in ("register", "status"):
+            continue
+        try:
+            with open(f"{BINFMT_DIR}/{name}", encoding="utf-8", errors="replace") as fh:
+                parsed = _parse_entry(fh.read())
+        except OSError:
+            continue
+        if parsed is None:
+            continue
+        interpreter, offset, magic, mask = parsed
+        if _entry_matches(offset, magic, mask, header):
+            return interpreter
+    return None
+
+
+def covered_arches() -> list[str]:
+    """Return the foreign arches an enabled entry can already run, sorted."""
+    return sorted(arch for arch in _QEMU_BINARY if registered_interpreter(arch))
+
+
+def find_emulator(arch: str) -> str | None:
+    """Return the path of an installed QEMU user-mode emulator for *arch*, or None."""
+    name = _QEMU_BINARY.get(arch)
+    if name is None:
+        return None
+    for candidate in (f"{name}-static", name):
+        for directory in _SEARCH_DIRS:
+            path = f"{directory}/{candidate}"
+            if os.access(path, os.X_OK) and os.path.isfile(path):
+                return path
+    return None
+
+
+def _escape(raw: bytes) -> str:
+    r"""Return *raw* as the \xNN escapes a register line's magic and mask take."""
+    return "".join(f"\\x{byte:02x}" for byte in raw)
+
+
+def ensure_handler(arch: str) -> tuple[str | None, str]:
+    """Give *arch* a binfmt_misc handler, registering one when nothing answers yet.
+
+    Returns (interpreter, "") once *arch* is covered, else (None, reason). Needs
+    root, and the registration outlives the session: an entry stands until it is
+    removed or the host reboots, exactly like a distro's qemu-user-static.
+    """
+    existing = registered_interpreter(arch)
+    if existing:
+        return existing, ""
+    if os.environ.get("CD_NO_BINFMT", "").strip().lower() in _TRUTHY:
+        return None, "disabled via CD_NO_BINFMT"
+    signature = _elf_signature(arch)
+    if signature is None:
+        return None, f"no ELF signature is known for '{arch}'"
+    if not os.path.exists(_REGISTER):
+        return None, "this kernel has no binfmt_misc (CONFIG_BINFMT_MISC)"
+    emulator = find_emulator(arch)
+    if emulator is None:
+        return None, f"no QEMU user-mode emulator for '{arch}' is installed"
+    if len(emulator.encode()) > _MAX_INTERPRETER or ":" in emulator:
+        return None, f"the kernel cannot take '{emulator}' as an interpreter path"
+    magic, mask = signature
+    line = f":cd-qemu-{arch}:M:0:{_escape(magic)}:{_escape(mask)}:{emulator}:PF\n"
+    try:
+        with open(_REGISTER, "w", encoding="ascii") as fh:
+            fh.write(line)
+    except OSError as exc:
+        # A concurrent session may have registered this name first.
+        covered = registered_interpreter(arch)
+        if covered:
+            return covered, ""
+        return None, f"binfmt_misc refused the registration ({exc})"
+    log_info(f"Registered {emulator} as the binfmt_misc interpreter for '{arch}'.")
+    return emulator, ""

--- a/tests/unit/test_arch.py
+++ b/tests/unit/test_arch.py
@@ -5,6 +5,7 @@ from chroot_distro.arch import (
     _elf_arch,
     detect_installed_arch,
     get_device_cpu_arch,
+    needs_emulation,
     normalize_arch,
     supports_32bit,
 )
@@ -121,3 +122,17 @@ def test_detect_installed_arch(mock_container_rootfs, tmp_path):
     # Test unknown
     bash_path.unlink()
     assert detect_installed_arch("my_container") == "unknown"
+
+
+def test_needs_emulation():
+    assert needs_emulation("x86_64", "x86_64") is False
+    assert needs_emulation("aarch64", "x86_64") is True
+
+    with patch("chroot_distro.arch.supports_32bit", return_value=True):
+        assert needs_emulation("i686", "x86_64") is False
+        assert needs_emulation("arm", "aarch64") is False
+        # A 64-bit CPU only runs the 32-bit half of its own family.
+        assert needs_emulation("i686", "aarch64") is True
+
+    with patch("chroot_distro.arch.supports_32bit", return_value=False):
+        assert needs_emulation("arm", "aarch64") is True

--- a/tests/unit/test_binfmt.py
+++ b/tests/unit/test_binfmt.py
@@ -1,0 +1,149 @@
+import os
+from unittest.mock import patch
+
+from chroot_distro.helpers import binfmt
+
+# Straight from qemu's own scripts/qemu-binfmt-conf.sh, so a drift in the
+# generated signature shows up as a diff against the reference, not a guess.
+QEMU_AARCH64_MAGIC = b"\x7fELF\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\xb7\x00"
+QEMU_AARCH64_MASK = b"\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff"
+
+
+def _write_entry(directory, name, *, interpreter, magic, mask, enabled=True, offset=0):
+    head = "enabled\n" if enabled else "disabled\n"
+    body = f"interpreter {interpreter}\nflags: PF\noffset {offset}\nmagic {magic.hex()}\nmask {mask.hex()}\n"
+    (directory / name).write_text(head + body)
+
+
+def test_elf_signature_matches_qemus_own_table():
+    assert binfmt._elf_signature("aarch64") == (QEMU_AARCH64_MAGIC, QEMU_AARCH64_MASK)
+    assert binfmt._elf_signature("mips") is None
+
+
+def test_registered_interpreter_matches_by_magic_not_by_name(tmp_path):
+    _write_entry(
+        tmp_path,
+        "some-vendor-name",
+        interpreter="/usr/bin/qemu-aarch64-static",
+        magic=QEMU_AARCH64_MAGIC,
+        mask=QEMU_AARCH64_MASK,
+    )
+    with patch.object(binfmt, "BINFMT_DIR", str(tmp_path)):
+        assert binfmt.registered_interpreter("aarch64") == "/usr/bin/qemu-aarch64-static"
+        assert binfmt.registered_interpreter("riscv64") is None
+
+
+def test_registered_interpreter_ignores_entries_it_cannot_judge(tmp_path):
+    _write_entry(
+        tmp_path,
+        "qemu-aarch64",
+        interpreter="/usr/bin/qemu-aarch64-static",
+        magic=QEMU_AARCH64_MAGIC,
+        mask=QEMU_AARCH64_MASK,
+        enabled=False,
+    )
+    (tmp_path / "python3.12").write_text("enabled\ninterpreter /usr/bin/python3.12\nflags: \nextension .py\n")
+    with patch.object(binfmt, "BINFMT_DIR", str(tmp_path)):
+        assert binfmt.registered_interpreter("aarch64") is None
+
+
+def test_ensure_handler_registers_with_the_fix_binary_flag(tmp_path):
+    register = tmp_path / "register"
+    register.write_text("")
+    with (
+        patch.object(binfmt, "BINFMT_DIR", str(tmp_path)),
+        patch.object(binfmt, "_REGISTER", str(register)),
+        patch.object(binfmt, "find_emulator", return_value="/usr/bin/qemu-aarch64-static"),
+    ):
+        interpreter, reason = binfmt.ensure_handler("aarch64")
+
+    assert (interpreter, reason) == ("/usr/bin/qemu-aarch64-static", "")
+    fields = register.read_text().strip("\n").split(":")
+    assert fields[1] == "cd-qemu-aarch64"
+    assert fields[2] == "M"
+    assert fields[6] == "/usr/bin/qemu-aarch64-static"
+    # F is what survives the chroot; C would make setuid a host-wide escalation.
+    assert "F" in fields[7] and "C" not in fields[7]
+    assert fields[4] == "".join(f"\\x{b:02x}" for b in QEMU_AARCH64_MAGIC)
+
+
+def test_ensure_handler_leaves_an_existing_entry_alone(tmp_path):
+    register = tmp_path / "register"
+    register.write_text("")
+    _write_entry(
+        tmp_path,
+        "qemu-aarch64",
+        interpreter="/opt/qemu-aarch64",
+        magic=QEMU_AARCH64_MAGIC,
+        mask=QEMU_AARCH64_MASK,
+    )
+    with (
+        patch.object(binfmt, "BINFMT_DIR", str(tmp_path)),
+        patch.object(binfmt, "_REGISTER", str(register)),
+    ):
+        assert binfmt.ensure_handler("aarch64") == ("/opt/qemu-aarch64", "")
+    assert register.read_text() == ""
+
+
+def test_ensure_handler_reports_why_it_could_not_register(tmp_path):
+    register = tmp_path / "register"
+    register.write_text("")
+    with (
+        patch.object(binfmt, "BINFMT_DIR", str(tmp_path)),
+        patch.object(binfmt, "_REGISTER", str(register)),
+        patch.object(binfmt, "find_emulator", return_value=None),
+    ):
+        interpreter, reason = binfmt.ensure_handler("aarch64")
+    assert interpreter is None
+    assert "emulator" in reason
+
+    with (
+        patch.object(binfmt, "BINFMT_DIR", str(tmp_path)),
+        patch.object(binfmt, "_REGISTER", str(tmp_path / "absent")),
+    ):
+        interpreter, reason = binfmt.ensure_handler("aarch64")
+    assert interpreter is None
+    assert "CONFIG_BINFMT_MISC" in reason
+
+
+def test_ensure_handler_honours_cd_no_binfmt(tmp_path, monkeypatch):
+    monkeypatch.setenv("CD_NO_BINFMT", "1")
+    with patch.object(binfmt, "BINFMT_DIR", str(tmp_path)):
+        interpreter, reason = binfmt.ensure_handler("aarch64")
+    assert interpreter is None
+    assert "CD_NO_BINFMT" in reason
+
+
+def test_cd_no_binfmt_still_reports_an_entry_someone_else_registered(tmp_path, monkeypatch):
+    monkeypatch.setenv("CD_NO_BINFMT", "1")
+    _write_entry(
+        tmp_path,
+        "qemu-aarch64",
+        interpreter="/usr/bin/qemu-aarch64-static",
+        magic=QEMU_AARCH64_MAGIC,
+        mask=QEMU_AARCH64_MASK,
+    )
+    with patch.object(binfmt, "BINFMT_DIR", str(tmp_path)):
+        assert binfmt.ensure_handler("aarch64") == ("/usr/bin/qemu-aarch64-static", "")
+
+
+def test_find_emulator_prefers_a_static_build(tmp_path):
+    for name in ("qemu-aarch64", "qemu-aarch64-static"):
+        path = tmp_path / name
+        path.write_text("")
+        os.chmod(path, 0o755)
+    with patch.object(binfmt, "_SEARCH_DIRS", (str(tmp_path),)):
+        assert binfmt.find_emulator("aarch64") == f"{tmp_path}/qemu-aarch64-static"
+        assert binfmt.find_emulator("riscv64") is None
+
+
+def test_covered_arches_lists_what_can_run(tmp_path):
+    _write_entry(
+        tmp_path,
+        "qemu-aarch64",
+        interpreter="/usr/bin/qemu-aarch64-static",
+        magic=QEMU_AARCH64_MAGIC,
+        mask=QEMU_AARCH64_MASK,
+    )
+    with patch.object(binfmt, "BINFMT_DIR", str(tmp_path)):
+        assert binfmt.covered_arches() == ["aarch64"]

--- a/tests/unit/test_build_install_as_guard.py
+++ b/tests/unit/test_build_install_as_guard.py
@@ -67,3 +67,37 @@ def test_a_free_name_gets_past_the_guard(build_dir, containers, monkeypatch):
 
     with pytest.raises(ChrootDistroError, match="reached the build"):
         command_build(_args(build_dir, "free"))
+
+
+def test_foreign_build_with_run_refuses_without_an_emulator(build_dir, monkeypatch, capsys):
+    (build_dir / "Dockerfile").write_text("FROM alpine\nRUN echo hello\n")
+    monkeypatch.setattr("chroot_distro.commands.build.get_device_cpu_arch", lambda: "x86_64")
+    monkeypatch.setattr("chroot_distro.commands.build.needs_emulation", lambda _arch: True)
+    monkeypatch.setattr(
+        "chroot_distro.commands.build.ensure_handler",
+        lambda _arch: (None, "no QEMU user-mode emulator is installed"),
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        command_build(SimpleNamespace(path=str(build_dir), override_arch="aarch64", quiet=True))
+
+    assert exc.value.code == 1
+    assert "RUN steps cannot execute" in capsys.readouterr().err
+
+
+def test_foreign_build_without_run_warns_but_can_finish(build_dir, monkeypatch, capsys):
+    monkeypatch.setattr("chroot_distro.commands.build.get_device_cpu_arch", lambda: "x86_64")
+    monkeypatch.setattr("chroot_distro.commands.build.needs_emulation", lambda _arch: True)
+    monkeypatch.setattr(
+        "chroot_distro.commands.build.ensure_handler",
+        lambda _arch: (None, "no QEMU user-mode emulator is installed"),
+    )
+
+    def boom(*_args, **_kwargs):
+        raise ChrootDistroError("reached the build")
+
+    monkeypatch.setattr("chroot_distro.commands.build.BuildLock", boom)
+    with pytest.raises(ChrootDistroError, match="reached the build"):
+        command_build(SimpleNamespace(path=str(build_dir), override_arch="aarch64", quiet=True))
+
+    assert "no emulator was registered" in capsys.readouterr().err

--- a/tests/unit/test_info.py
+++ b/tests/unit/test_info.py
@@ -130,17 +130,17 @@ def test_detect_escalation_tool_prefers_sudo():
 def test_binfmt_qemu_status_flags_missing_handler_when_emulation_needed():
     with (
         patch("os.path.isdir", return_value=True),
-        patch("os.listdir", return_value=["status", "register"]),
+        patch("chroot_distro.commands.info.covered_arches", return_value=[]),
     ):
         value, level = info._binfmt_qemu_status(needs_emulation=True)
     assert level == "bad"
-    assert "no qemu handler" in value
+    assert "no emulator" in value
 
 
 def test_binfmt_qemu_status_ok_with_handler():
     with (
         patch("os.path.isdir", return_value=True),
-        patch("os.listdir", return_value=["qemu-aarch64", "qemu-arm", "status"]),
+        patch("chroot_distro.commands.info.covered_arches", return_value=["aarch64", "arm"]),
     ):
         value, level = info._binfmt_qemu_status(needs_emulation=True)
     assert level == "ok"

--- a/tests/unit/test_login_helpers.py
+++ b/tests/unit/test_login_helpers.py
@@ -1437,3 +1437,123 @@ def test_live_mount_options_requires_a_live_session(monkeypatch):
 
     monkeypatch.setattr(session_mod, "get_active_chroot_pids", lambda name: [123])
     assert session_mod.live_mount_options("box") == {"shared_home": True}
+
+
+def test_special_mounts_skips_binfmt_under_a_user_namespace():
+    from chroot_distro.commands.login.bindings import get_special_mounts
+
+    with (
+        patch("chroot_distro.commands.login.bindings._fs_supported", return_value=True),
+        patch("os.path.exists", return_value=True),
+    ):
+        plain = get_special_mounts("/fake/rootfs")
+        userns = get_special_mounts("/fake/rootfs", use_userns=True)
+
+    # A fresh instance inside the userns would be empty, shadowing the host's
+    # entries that an unmounted one inherits instead.
+    assert "binfmt_misc" in [sm.fstype for sm in plain]
+    assert "binfmt_misc" not in [sm.fstype for sm in userns]
+
+
+def _aarch64_rootfs(tmp_path):
+    """A rootfs whose own /bin/sh reports EM_AARCH64, the way a real one would."""
+    import struct
+
+    header = bytearray(20)
+    header[:4] = b"\x7fELF"
+    header[4] = 2  # EI_CLASS: 64-bit
+    header[5] = 1  # EI_DATA: little endian
+    struct.pack_into("<H", header, 18, 183)  # EM_AARCH64
+    rootfs = tmp_path / "rootfs"
+    (rootfs / "bin").mkdir(parents=True)
+    (rootfs / "bin" / "sh").write_bytes(bytes(header))
+    return rootfs
+
+
+def test_ensure_guest_arch_runnable_registers_a_handler_for_a_foreign_image(tmp_path):
+    import json
+
+    from chroot_distro.commands.login import _ensure_guest_arch_runnable
+
+    (tmp_path / "manifest.json").write_text(json.dumps({"arch": "arm64"}))
+    with (
+        patch("chroot_distro.arch.get_device_cpu_arch", return_value="x86_64"),
+        patch(
+            "chroot_distro.helpers.binfmt.ensure_handler",
+            return_value=("/usr/bin/qemu-aarch64-static", ""),
+        ) as ensure,
+        patch("chroot_distro.commands.login.warn") as warned,
+    ):
+        _ensure_guest_arch_runnable(str(tmp_path), str(tmp_path / "empty-rootfs"))
+
+    ensure.assert_called_once_with("aarch64")
+    warned.assert_not_called()
+
+
+def test_ensure_guest_arch_runnable_only_warns_when_the_manifest_alone_says_foreign(tmp_path):
+    import json
+
+    from chroot_distro.commands.login import _ensure_guest_arch_runnable
+
+    (tmp_path / "manifest.json").write_text(json.dumps({"arch": "arm64"}))
+    with (
+        patch("chroot_distro.arch.get_device_cpu_arch", return_value="x86_64"),
+        patch("chroot_distro.helpers.binfmt.ensure_handler", return_value=(None, "no QEMU for it")),
+        patch("chroot_distro.commands.login.warn") as warned,
+    ):
+        # No SystemExit: a manifest can name a platform its files do not match.
+        _ensure_guest_arch_runnable(str(tmp_path), str(tmp_path / "empty-rootfs"))
+
+    assert "no QEMU for it" in warned.call_args[0][0]
+
+
+def test_ensure_guest_arch_runnable_refuses_when_the_rootfs_confirms_it(tmp_path):
+    import pytest
+
+    from chroot_distro.commands.login import _ensure_guest_arch_runnable
+
+    rootfs = _aarch64_rootfs(tmp_path)
+    with (
+        patch("chroot_distro.arch.get_device_cpu_arch", return_value="x86_64"),
+        patch("chroot_distro.helpers.binfmt.ensure_handler", return_value=(None, "no QEMU for it")),
+        patch("chroot_distro.commands.login.crit_error") as errored,
+        pytest.raises(SystemExit) as exit_info,
+    ):
+        _ensure_guest_arch_runnable(str(tmp_path), str(rootfs))
+
+    assert exit_info.value.code == 1
+    assert "cannot execute" in errored.call_args[0][0]
+
+
+def test_ensure_guest_arch_runnable_uses_the_rootfs_when_there_is_no_manifest(tmp_path):
+    from chroot_distro.commands.login import _ensure_guest_arch_runnable
+
+    rootfs = _aarch64_rootfs(tmp_path)
+    with (
+        patch("chroot_distro.arch.get_device_cpu_arch", return_value="x86_64"),
+        patch(
+            "chroot_distro.helpers.binfmt.ensure_handler",
+            return_value=("/usr/bin/qemu-aarch64-static", ""),
+        ) as ensure,
+    ):
+        _ensure_guest_arch_runnable(str(tmp_path), str(rootfs))
+
+    ensure.assert_called_once_with("aarch64")
+
+
+def test_ensure_guest_arch_runnable_stays_quiet_for_a_32bit_guest_on_a_64bit_host(tmp_path):
+    import json
+
+    from chroot_distro.commands.login import _ensure_guest_arch_runnable
+
+    (tmp_path / "manifest.json").write_text(json.dumps({"arch": "386"}))
+    with (
+        patch("chroot_distro.arch.get_device_cpu_arch", return_value="x86_64"),
+        patch("chroot_distro.arch.supports_32bit", return_value=True),
+        patch("chroot_distro.helpers.binfmt.ensure_handler") as ensure,
+        patch("chroot_distro.commands.login.warn") as warned,
+    ):
+        _ensure_guest_arch_runnable(str(tmp_path), str(tmp_path / "empty-rootfs"))
+
+    ensure.assert_not_called()
+    warned.assert_not_called()


### PR DESCRIPTION
Register QEMU user-mode handlers before foreign guest execution and fail early when confirmed foreign binaries cannot run.